### PR TITLE
fix: guard toy filter surfaceargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 ## [v5.7.5](https://github.com/doadin/Baggins/tree/v5.7.5) (2025-08-08)
 [Full Changelog](https://github.com/doadin/Baggins/compare/v5.7.4...v5.7.5) [Previous Releases](https://github.com/doadin/Baggins/releases)
 
-- [Baggins] Handle Missing Frame in ReallyUpdateBags  
+- [Baggins] Handle Missing Frame in ReallyUpdateBags
+- [Baggins] Guard Toy filter SurfaceArgs calls

--- a/src/filters/Toy.lua
+++ b/src/filters/Toy.lua
@@ -7,15 +7,18 @@ Toy.lua
 local AddOnName, _ = ...
 local AddOn = _G[AddOnName]
 
-local C_TooltipInfoGetBagItem = C_TooltipInfo.GetBagItem
-local TooltipUtil = TooltipUtil
+local C_TooltipInfoGetBagItem = C_TooltipInfo and C_TooltipInfo.GetBagItem
+local TooltipUtil = TooltipUtil and TooltipUtil
 
 local function Matches(bag, slot, _)
+    if not C_TooltipInfoGetBagItem then return false end
     local tooltipData = C_TooltipInfoGetBagItem(bag, slot)
     if not tooltipData then return false end
-    TooltipUtil.SurfaceArgs(tooltipData)
-    for _, line in ipairs(tooltipData.lines) do
-        TooltipUtil.SurfaceArgs(line)
+    if TooltipUtil and TooltipUtil.SurfaceArgs then
+        TooltipUtil.SurfaceArgs(tooltipData)
+        for _, line in ipairs(tooltipData.lines) do
+            TooltipUtil.SurfaceArgs(line)
+        end
     end
 
     -- The above SurfaceArgs calls are required to assign values to the


### PR DESCRIPTION
## Summary
- avoid calling TooltipUtil.SurfaceArgs when unavailable
- note guard in changelog

## Testing
- `luac -p src/filters/Toy.lua` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c164fcfc832ca77b271bd64de325